### PR TITLE
[StatsD] clear data after flush

### DIFF
--- a/src/Beberlei/Metrics/Collector/StatsD.php
+++ b/src/Beberlei/Metrics/Collector/StatsD.php
@@ -96,5 +96,7 @@ class StatsD implements Collector
             fclose($fp);
         } catch (Exception $e) {
         }
+
+        $this->data = array();
     }
 }


### PR DESCRIPTION
This clears the data after flushing to statsd, so that flushing multiple times doesn't send the same data twice
