### PR TITLE
Fixed statsd collector when stastd is down

### DIFF
--- a/src/Beberlei/Metrics/Collector/StatsD.php
+++ b/src/Beberlei/Metrics/Collector/StatsD.php
@@ -87,9 +87,11 @@ class StatsD implements Collector
             return;
         }
 
+        $level = error_reporting(0);
         foreach ($this->data as $line) {
-            @fwrite($fp, $line);
+            fwrite($fp, $line);
         }
+        error_reporting($level);
 
         fclose($fp);
 


### PR DESCRIPTION
Code to reproduce:

```
<?php

// Note: nothing listen on port 12345!!
$fp = fsockopen("udp://localhost", 12345, $errno, $errstr, 1.0);
var_dump($fp, $errno, $errstr); // Everything OK
fwrite($fp, "1"); // OK
fwrite($fp, "1"); // KO
fclose($fp);

echo "END";
```

Note: 

No need to try catch, no exception can be trowed, and actually the code catch only `Beberlei\Metrics\Exception` which does not exist.
