### PR TITLE
Deprecated Collector\Null, replaced by Collector\NullCollector fix #32

### DIFF
--- a/src/Beberlei/Bundle/MetricsBundle/Resources/config/metrics.xml
+++ b/src/Beberlei/Bundle/MetricsBundle/Resources/config/metrics.xml
@@ -32,7 +32,7 @@
             <argument type="service" id="logger" />
             <tag name="monolog.logger" channel="beberlei_metrics" />
         </service>
-        <service id="beberlei_metrics.collector_proto.null" class="Beberlei\Metrics\Collector\Null" abstract="true">
+        <service id="beberlei_metrics.collector_proto.null" class="Beberlei\Metrics\Collector\NullCollector" abstract="true">
         </service>
         <service id="beberlei_metrics.collector_proto.statsd" class="Beberlei\Metrics\Collector\StatsD" abstract="true">
             <argument /> <!-- host, set by the extension -->

--- a/src/Beberlei/Bundle/MetricsBundle/Tests/DependencyInjection/BeberleiMetricsExtensionTest.php
+++ b/src/Beberlei/Bundle/MetricsBundle/Tests/DependencyInjection/BeberleiMetricsExtensionTest.php
@@ -99,7 +99,7 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('Beberlei\Metrics\Collector\Logger', $container->get('beberlei_metrics.collector.logger'));
     }
 
-    public function testWithNull()
+    public function testWithNullCollector()
     {
         $container = $this->createContainer(array(
             'collectors' => array(
@@ -109,7 +109,7 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
             ),
         ));
 
-        $this->assertInstanceOf('Beberlei\Metrics\Collector\Null', $container->get('beberlei_metrics.collector.null'));
+        $this->assertInstanceOf('Beberlei\Metrics\Collector\NullCollector', $container->get('beberlei_metrics.collector.null'));
     }
 
     public function testWithStatsD()

--- a/src/Beberlei/Metrics/Collector/NullCollector.php
+++ b/src/Beberlei/Metrics/Collector/NullCollector.php
@@ -13,9 +13,24 @@
 
 namespace Beberlei\Metrics\Collector;
 
-/**
- * @deprecated for PHP7 compatibility, use NullCollector instead.
- */
-class Null extends NullCollector
+class NullCollector implements Collector
 {
+    public function increment($variable)
+    {
+    }
+    public function decrement($variable)
+    {
+    }
+    public function timing($variable, $time)
+    {
+    }
+    public function measure($variable, $value)
+    {
+    }
+    public function gauge($variable, $value)
+    {
+    }
+    public function flush()
+    {
+    }
 }

--- a/src/Beberlei/Metrics/Factory.php
+++ b/src/Beberlei/Metrics/Factory.php
@@ -123,7 +123,7 @@ abstract class Factory
                 return new Collector\Logger($options['logger']);
 
             case 'null':
-                return new Collector\Null();
+                return new Collector\NullCollector();
 
             default:
                 throw new MetricsException(sprintf('Unknown metrics collector given (%s).', $type));

--- a/src/Beberlei/Metrics/Tests/FactoryTest.php
+++ b/src/Beberlei/Metrics/Tests/FactoryTest.php
@@ -21,7 +21,7 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
             array('Beberlei\Metrics\Collector\Librato', 'librato', array('hostname' => 'foobar.com', 'username' => 'username', 'password' => 'password')),
             array('Beberlei\Metrics\Collector\DoctrineDBAL', 'doctrine_dbal', array('connection' => $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock())),
             array('Beberlei\Metrics\Collector\Logger', 'logger', array('logger' => new NullLogger())),
-            array('Beberlei\Metrics\Collector\Null', 'null'),
+            array('Beberlei\Metrics\Collector\NullCollector', 'null'),
         );
     }
 


### PR DESCRIPTION
Fixes #32: Deprecated: Beberlei\Metrics\Collector\Null uses a reserved class name (Null) that will break on PHP 7 and higher