### PR TITLE
Add context logger

### DIFF
--- a/src/Beberlei/Metrics/Collector/ContextLogger.php
+++ b/src/Beberlei/Metrics/Collector/ContextLogger.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Beberlei Metrics
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+
+namespace Beberlei\Metrics\Collector;
+
+use Psr\Log\LoggerInterface;
+
+class ContextLogger implements Collector
+{
+    private $logger;
+
+    public function __construct(LoggerInterface $logger)
+    {
+        $this->logger = $logger;
+    }
+
+    public function increment($variable)
+    {
+        $this->logger->debug('{type}:{variable}', array('type' => 'increment', 'variable' => $variable));
+    }
+
+    public function decrement($variable)
+    {
+        $this->logger->debug('{type}:{variable}', array('type' => 'decrement', 'variable' => $variable));
+    }
+
+    public function timing($variable, $time)
+    {
+        $this->logger->debug(
+            '{type}:{variable}:{time}', array('type' => 'timing', 'variable' => $variable, 'value' => $time)
+        );
+    }
+
+    public function measure($variable, $value)
+    {
+        $this->logger->debug(
+            '{type}:{variable}:{value}', array('type' => 'measure', 'variable' => $variable, 'value' => $value)
+        );
+    }
+
+    public function flush()
+    {
+    }
+}

--- a/src/Beberlei/Metrics/Factory.php
+++ b/src/Beberlei/Metrics/Factory.php
@@ -115,6 +115,13 @@ abstract class Factory
 
                 return new Collector\DoctrineDBAL($options['connection']);
 
+            case 'context_logger':
+                if (!isset($options['logger'])) {
+                    throw new MetricsException("Missing 'logger' key with logger service.");
+                }
+
+                return new Collector\ContextLogger($options['logger']);
+
             case 'logger':
                 if (!isset($options['logger'])) {
                     throw new MetricsException("Missing 'logger' key with logger service.");


### PR DESCRIPTION
The context logger makes use of the context array replacement feature
defined in PSR-3. See
https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-3-logger-interface.md#12-message
for an example.

If you use monolog you should add the PsrLogMessageProcessor to your
logger to enable replacement of the variables.
