### PR TITLE
Added in memory collector

### DIFF
--- a/src/Beberlei/Bundle/MetricsBundle/DependencyInjection/BeberleiMetricsExtension.php
+++ b/src/Beberlei/Bundle/MetricsBundle/DependencyInjection/BeberleiMetricsExtension.php
@@ -78,6 +78,7 @@ class BeberleiMetricsExtension extends Extension
                 return $definition;
             case 'logger':
             case 'null':
+            case 'memory':
                 return $definition;
             case 'prometheus':
                 $definition->replaceArgument(0, new Reference($config['prometheus_collector_registry']));

--- a/src/Beberlei/Bundle/MetricsBundle/Resources/config/metrics.xml
+++ b/src/Beberlei/Bundle/MetricsBundle/Resources/config/metrics.xml
@@ -60,6 +60,8 @@
             <argument /> <!-- sender, set by the extension -->
             <argument /> <!-- host, set by the extension -->
         </service>
+        <service id="beberlei_metrics.collector_proto.memory" class="Beberlei\Metrics\Collector\InMemory" abstract="true">
+        </service>
     </services>
 
 </container>

--- a/src/Beberlei/Bundle/MetricsBundle/Tests/DependencyInjection/BeberleiMetricsExtensionTest.php
+++ b/src/Beberlei/Bundle/MetricsBundle/Tests/DependencyInjection/BeberleiMetricsExtensionTest.php
@@ -330,6 +330,19 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
         $this->assertSame('', $this->getProperty($collector, 'namespace'));
     }
 
+    public function testWithInMemory()
+    {
+        $container = $this->createContainer(array(
+            'collectors' => array(
+                'memory' => array(
+                    'type' => 'memory'
+                )
+            ),
+        ));
+        $collector = $container->get('beberlei_metrics.collector.memory');
+        $this->assertInstanceOf('Beberlei\Metrics\Collector\InMemory', $collector);
+    }
+
     public function testWithPrometheusAndWithNamespace()
     {
         $expectedNamespace = 'some_namespace';

--- a/src/Beberlei/Metrics/Collector/InMemory.php
+++ b/src/Beberlei/Metrics/Collector/InMemory.php
@@ -1,0 +1,101 @@
+<?php
+/**
+ * Beberlei Metrics.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+namespace Beberlei\Metrics\Collector;
+
+/**
+ * Stores metrics in memory.
+ * Useful for testing and with any custom persistence mechanisms.
+ */
+class InMemory implements Collector, GaugeableCollector
+{
+    /** @var  int[] */
+    private $data = [];
+
+    /**
+     * Updates a counter by some arbitrary amount.
+     *
+     * @param string $variable
+     * @param int $value The amount to increment the counter by
+     */
+    public function measure($variable, $value)
+    {
+        if (!isset($this->data[$variable])) {
+            $this->data[$variable] = 0;
+        }
+        $this->data[$variable] += $value;
+    }
+
+    /**
+     * Increments a counter.
+     *
+     * @param string $variable
+     */
+    public function increment($variable)
+    {
+        $this->measure($variable, 1);
+    }
+
+    /**
+     * Decrements a counter.
+     *
+     * @param string $variable
+     */
+    public function decrement($variable)
+    {
+        $this->measure($variable, -1);
+    }
+
+    /**
+     * Records a timing.
+     *
+     * @param string $variable
+     * @param int $time The duration of the timing in milliseconds
+     */
+    public function timing($variable, $time)
+    {
+        $this->gauge($variable, $time);
+    }
+
+    /**
+     * Sends the metrics to the adapter backend.
+     */
+    public function flush()
+    {
+        // TODO: Implement flush() method.
+    }
+
+    /**
+     * Updates a gauge by an arbitrary amount.
+     *
+     * @param string $variable
+     * @param int $value
+     */
+    public function gauge($variable, $value)
+    {
+        if (!isset($this->data[$variable])) {
+            $this->data[$variable] = 0;
+        }
+        $this->data[$variable] = $value;
+    }
+
+    /**
+     * Returns current value of variable
+     *
+     * @param string $variable
+     * @return int
+     */
+    public function get($variable)
+    {
+        return $this->data[$variable];
+    }
+}

--- a/src/Beberlei/Metrics/Tests/Collector/InMemoryTest.php
+++ b/src/Beberlei/Metrics/Tests/Collector/InMemoryTest.php
@@ -96,6 +96,18 @@ class InMemoryTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(9, $this->collector->getGauge(self::VARIABLE_A));
     }
 
+    public function testSettingGaugeToNegativeValue()
+    {
+        $this->collector->gauge(self::VARIABLE_A, 1); //sets to 1
+        $this->collector->gauge(self::VARIABLE_A, 2); //sets to 2
+        $this->collector->gauge(self::VARIABLE_A, -5); //decreases by 5
+        $this->assertEquals(-3, $this->collector->getGauge(self::VARIABLE_A));
+
+        $this->collector->gauge(self::VARIABLE_A, 0);
+        $this->collector->gauge(self::VARIABLE_A, -5);
+        $this->assertEquals(-5, $this->collector->getGauge(self::VARIABLE_A));
+    }
+
     public function testTypesOfMetricsAreSeparate()
     {
         $this->collector->increment(self::VARIABLE_A);

--- a/src/Beberlei/Metrics/Tests/Collector/InMemoryTest.php
+++ b/src/Beberlei/Metrics/Tests/Collector/InMemoryTest.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Beberlei Metrics.
+ *
+ * LICENSE
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this package in the file LICENSE.txt.
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to kontakt@beberlei.de so I can send you a copy immediately.
+ */
+namespace Beberlei\Metrics\Tests\Collector;
+
+use Beberlei\Metrics\Collector\InMemory;
+
+class InMemoryTest extends \PHPUnit_Framework_TestCase
+{
+    const VARIABLE_A = 'variable_a';
+    const VARIABLE_B = 'variable_b';
+
+    /** @var  InMemory */
+    private $collector;
+
+    public function setUp()
+    {
+        $this->collector = new InMemory();
+    }
+
+    public function test_increment()
+    {
+        $this->collector->increment(self::VARIABLE_A);
+        $this->collector->increment(self::VARIABLE_A);
+
+        $this->collector->increment(self::VARIABLE_B);
+
+        $this->assertEquals(2, $this->collector->get(self::VARIABLE_A));
+        $this->assertEquals(1, $this->collector->get(self::VARIABLE_B));
+    }
+
+    public function test_decrement()
+    {
+        $this->collector->increment(self::VARIABLE_A);
+        $this->collector->increment(self::VARIABLE_A);
+        $this->collector->decrement(self::VARIABLE_A);
+
+        $this->collector->decrement(self::VARIABLE_B);
+        $this->collector->decrement(self::VARIABLE_B);
+
+        $this->assertEquals(1, $this->collector->get(self::VARIABLE_A));
+        $this->assertEquals(-2, $this->collector->get(self::VARIABLE_B));
+    }
+
+    public function test_timing()
+    {
+        $this->collector->timing(self::VARIABLE_A, 123);
+
+        $this->collector->timing(self::VARIABLE_B, 111);
+        $this->collector->timing(self::VARIABLE_B, 112);
+
+        $this->assertEquals(123, $this->collector->get(self::VARIABLE_A));
+        $this->assertEquals(112, $this->collector->get(self::VARIABLE_B));
+    }
+
+    public function test_measure()
+    {
+        $this->collector->measure(self::VARIABLE_A, 2);
+        $this->collector->measure(self::VARIABLE_A, -5);
+
+        $this->collector->measure(self::VARIABLE_B, 123);
+        $this->collector->measure(self::VARIABLE_B, 0);
+
+        $this->assertEquals(-3, $this->collector->get(self::VARIABLE_A));
+        $this->assertEquals(123, $this->collector->get(self::VARIABLE_B));
+    }
+
+    public function test_gauge()
+    {
+        $this->collector->gauge(self::VARIABLE_A, 2);
+        $this->collector->gauge(self::VARIABLE_A, -5);
+
+        $this->collector->gauge(self::VARIABLE_B, 123);
+        $this->collector->gauge(self::VARIABLE_B, 0);
+
+        $this->assertEquals(-5, $this->collector->get(self::VARIABLE_A));
+        $this->assertEquals(0, $this->collector->get(self::VARIABLE_B));
+    }
+}

--- a/src/Beberlei/Metrics/Tests/Collector/InMemoryTest.php
+++ b/src/Beberlei/Metrics/Tests/Collector/InMemoryTest.php
@@ -27,18 +27,18 @@ class InMemoryTest extends \PHPUnit_Framework_TestCase
         $this->collector = new InMemory();
     }
 
-    public function test_increment()
+    public function testIncrement()
     {
         $this->collector->increment(self::VARIABLE_A);
         $this->collector->increment(self::VARIABLE_A);
 
         $this->collector->increment(self::VARIABLE_B);
 
-        $this->assertEquals(2, $this->collector->get(self::VARIABLE_A));
-        $this->assertEquals(1, $this->collector->get(self::VARIABLE_B));
+        $this->assertEquals(2, $this->collector->getMeasure(self::VARIABLE_A));
+        $this->assertEquals(1, $this->collector->getMeasure(self::VARIABLE_B));
     }
 
-    public function test_decrement()
+    public function testDecrement()
     {
         $this->collector->increment(self::VARIABLE_A);
         $this->collector->increment(self::VARIABLE_A);
@@ -47,22 +47,22 @@ class InMemoryTest extends \PHPUnit_Framework_TestCase
         $this->collector->decrement(self::VARIABLE_B);
         $this->collector->decrement(self::VARIABLE_B);
 
-        $this->assertEquals(1, $this->collector->get(self::VARIABLE_A));
-        $this->assertEquals(-2, $this->collector->get(self::VARIABLE_B));
+        $this->assertEquals(1, $this->collector->getMeasure(self::VARIABLE_A));
+        $this->assertEquals(-2, $this->collector->getMeasure(self::VARIABLE_B));
     }
 
-    public function test_timing()
+    public function testTiming()
     {
         $this->collector->timing(self::VARIABLE_A, 123);
 
         $this->collector->timing(self::VARIABLE_B, 111);
         $this->collector->timing(self::VARIABLE_B, 112);
 
-        $this->assertEquals(123, $this->collector->get(self::VARIABLE_A));
-        $this->assertEquals(112, $this->collector->get(self::VARIABLE_B));
+        $this->assertEquals(123, $this->collector->getTiming(self::VARIABLE_A));
+        $this->assertEquals(112, $this->collector->getTiming(self::VARIABLE_B));
     }
 
-    public function test_measure()
+    public function testMeasure()
     {
         $this->collector->measure(self::VARIABLE_A, 2);
         $this->collector->measure(self::VARIABLE_A, -5);
@@ -70,19 +70,53 @@ class InMemoryTest extends \PHPUnit_Framework_TestCase
         $this->collector->measure(self::VARIABLE_B, 123);
         $this->collector->measure(self::VARIABLE_B, 0);
 
-        $this->assertEquals(-3, $this->collector->get(self::VARIABLE_A));
-        $this->assertEquals(123, $this->collector->get(self::VARIABLE_B));
+        $this->assertEquals(-3, $this->collector->getMeasure(self::VARIABLE_A));
+        $this->assertEquals(123, $this->collector->getMeasure(self::VARIABLE_B));
     }
 
-    public function test_gauge()
+    public function testSettingGauge()
     {
         $this->collector->gauge(self::VARIABLE_A, 2);
-        $this->collector->gauge(self::VARIABLE_A, -5);
+        $this->collector->gauge(self::VARIABLE_A, 5);
+
 
         $this->collector->gauge(self::VARIABLE_B, 123);
         $this->collector->gauge(self::VARIABLE_B, 0);
 
-        $this->assertEquals(-5, $this->collector->get(self::VARIABLE_A));
-        $this->assertEquals(0, $this->collector->get(self::VARIABLE_B));
+        $this->assertEquals(5, $this->collector->getGauge(self::VARIABLE_A));
+        $this->assertEquals(0, $this->collector->getGauge(self::VARIABLE_B));
+    }
+
+    public function testIncrementingGauge()
+    {
+        $this->collector->gauge(self::VARIABLE_A, '10');
+        $this->collector->gauge(self::VARIABLE_A, '+2');
+        $this->collector->gauge(self::VARIABLE_A, '-3');
+
+        $this->assertEquals(9, $this->collector->getGauge(self::VARIABLE_A));
+    }
+
+    public function testTypesOfMetricsAreSeparate()
+    {
+        $this->collector->increment(self::VARIABLE_A);
+        $this->collector->gauge(self::VARIABLE_A, 2);
+        $this->collector->timing(self::VARIABLE_A, 3);
+
+        $this->assertEquals(1, $this->collector->getMeasure(self::VARIABLE_A));
+        $this->assertEquals(2, $this->collector->getGauge(self::VARIABLE_A));
+        $this->assertEquals(3, $this->collector->getTiming(self::VARIABLE_A));
+    }
+
+    public function testFlushClearsData()
+    {
+        $this->collector->increment(self::VARIABLE_A);
+        $this->collector->gauge(self::VARIABLE_A, 2);
+        $this->collector->timing(self::VARIABLE_A, 3);
+
+        $this->collector->flush();
+
+        $this->assertEquals(0, $this->collector->getMeasure(self::VARIABLE_A));
+        $this->assertEquals(0, $this->collector->getGauge(self::VARIABLE_A));
+        $this->assertEquals(0, $this->collector->getTiming(self::VARIABLE_A));
     }
 }


### PR DESCRIPTION
Hi. 
I needed to measure processes' metrics and retrieve them in same request/run and hook it up with existing storing procedures. It will be useful to stick to same interface later when we will move that outside to graphite or something. I think it may be useful for others too in some cases.