### PR TITLE
Symfony 4 compat, require 3.3 or higher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,9 @@ language: php
 sudo: false
 
 php:
-  - 5.4
-  - 5.5
   - 5.6
   - 7.0
   - 7.1
-  - hhvm
 
 before_script:
   - if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi

--- a/composer.json
+++ b/composer.json
@@ -30,9 +30,9 @@
         "jimdo/prometheus_client_php": "^0.5",
         "kriswallsmith/buzz": "*",
         "okitsu/zabbix-sender": "*@dev",
-        "symfony/config": "~2.3",
-        "symfony/dependency-injection": "~2.3",
-        "symfony/http-kernel": "~2.3"
+        "symfony/config": "~3.3 || ~4.0",
+        "symfony/dependency-injection": "~3.3 || ~4.0",
+        "symfony/http-kernel": "~3.3 || ~4.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Beberlei/Bundle/MetricsBundle/DependencyInjection/BeberleiMetricsExtension.php
+++ b/src/Beberlei/Bundle/MetricsBundle/DependencyInjection/BeberleiMetricsExtension.php
@@ -6,7 +6,6 @@ use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ChildDefinition;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
-use Symfony\Component\DependencyInjection\DefinitionDecorator;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\HttpKernel\DependencyInjection\Extension;
@@ -37,11 +36,7 @@ class BeberleiMetricsExtension extends Extension
 
     private function createCollector($type, $config)
     {
-        if (class_exists('Symfony\Component\DependencyInjection\ChildDefinition')) {
-            $definition = new ChildDefinition('beberlei_metrics.collector_proto.'.$config['type']);
-        } else {
-            $definition = new DefinitionDecorator('beberlei_metrics.collector_proto.'.$config['type']);
-        }
+        $definition = new ChildDefinition('beberlei_metrics.collector_proto.'.$config['type']);
 
         // Theses listeners should be as late as possible
         $definition->addTag('kernel.event_listener', array(

--- a/src/Beberlei/Bundle/MetricsBundle/Tests/DependencyInjection/BeberleiMetricsExtensionTest.php
+++ b/src/Beberlei/Bundle/MetricsBundle/Tests/DependencyInjection/BeberleiMetricsExtensionTest.php
@@ -13,11 +13,12 @@
 
 namespace Beberlei\Bundle\MetricsBundle\Tests\DependencyInjection;
 
+use PHPUnit\Framework\TestCase;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
 use Beberlei\Bundle\MetricsBundle\DependencyInjection\BeberleiMetricsExtension;
 
-class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
+class BeberleiMetricsExtensionTest extends TestCase
 {
     public function testWithGraphite()
     {
@@ -34,6 +35,9 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
                     'protocol' => 'udp',
                 ),
             ),
+        ), array(
+            'beberlei_metrics.collector.simple',
+            'beberlei_metrics.collector.full'
         ));
 
         $collector = $container->get('beberlei_metrics.collector.simple');
@@ -61,7 +65,7 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
                     'type' => 'librato',
                 ),
             ),
-        ));
+        ), array('beberlei_metrics.collector.librato'));
 
         $this->assertInstanceOf('Beberlei\Metrics\Collector\Librato', $container->get('beberlei_metrics.collector.librato'));
     }
@@ -77,7 +81,7 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
                     'password' => 'bar',
                 ),
             ),
-        ));
+        ), array('beberlei_metrics.collector.full'));
 
         $collector = $container->get('beberlei_metrics.collector.full');
         $this->assertInstanceOf('Beberlei\Metrics\Collector\Librato', $collector);
@@ -94,7 +98,7 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
                     'type' => 'logger',
                 ),
             ),
-        ));
+        ), array('beberlei_metrics.collector.logger'));
 
         $this->assertInstanceOf('Beberlei\Metrics\Collector\Logger', $container->get('beberlei_metrics.collector.logger'));
     }
@@ -107,7 +111,7 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
                     'type' => 'null',
                 ),
             ),
-        ));
+        ), array('beberlei_metrics.collector.null'));
 
         $this->assertInstanceOf('Beberlei\Metrics\Collector\NullCollector', $container->get('beberlei_metrics.collector.null'));
     }
@@ -127,6 +131,9 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
                     'prefix' => 'application.com.symfony.',
                 ),
             ),
+        ), array(
+            'beberlei_metrics.collector.simple',
+            'beberlei_metrics.collector.full'
         ));
 
         $collector = $container->get('beberlei_metrics.collector.simple');
@@ -157,6 +164,9 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
                     'prefix' => 'application.com.symfony.',
                 ),
             ),
+        ), array(
+            'beberlei_metrics.collector.simple',
+            'beberlei_metrics.collector.full'
         ));
 
         $collector = $container->get('beberlei_metrics.collector.simple');
@@ -193,6 +203,9 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
                     'tags' => $expectedTags,
                 ),
             ),
+        ), array(
+            'beberlei_metrics.collector.simple',
+            'beberlei_metrics.collector.full'
         ));
 
         $collector = $container->get('beberlei_metrics.collector.simple');
@@ -230,6 +243,10 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
                     'file' => '/etc/zabbix/zabbix_agentd.conf',
                 ),
             ),
+        ), array(
+            'beberlei_metrics.collector.simple',
+            'beberlei_metrics.collector.full',
+            'beberlei_metrics.collector.file'
         ));
 
         $collector = $container->get('beberlei_metrics.collector.simple');
@@ -269,7 +286,7 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
                     'influxdb_client' => 'influxdb_client_mock',
                 ),
             ),
-        ), array(
+        ), array('beberlei_metrics.collector.influxdb'), array(
             'influxdb_client_mock' => $influxDBClientMock,
         ));
 
@@ -298,7 +315,7 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
                     'tags' => $expectedTags,
                 ),
             ),
-        ), array(
+        ), array('beberlei_metrics.collector.influxdb'), array(
             'influxdb_client_mock' => $influxDBClientMock,
         ));
 
@@ -321,7 +338,7 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
                     'prometheus_collector_registry' => 'prometheus_collector_registry_mock',
                 ),
             ),
-        ), array(
+        ), array('beberlei_metrics.collector.prometheus'), array(
             'prometheus_collector_registry_mock' => $prometheusCollectorRegistryMock,
         ));
 
@@ -339,7 +356,7 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
                     'type' => 'memory',
                 ),
             ),
-        ));
+        ), array('beberlei_metrics.collector.memory'));
         $collector = $container->get('beberlei_metrics.collector.memory');
         $this->assertInstanceOf('Beberlei\Metrics\Collector\InMemory', $collector);
     }
@@ -361,7 +378,7 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
                     'namespace' => $expectedNamespace,
                 ),
             ),
-        ), array(
+        ), array('beberlei_metrics.collector.prometheus'), array(
             'prometheus_collector_registry_mock' => $prometheusCollectorRegistryMock,
         ));
 
@@ -391,7 +408,7 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
                     'tags' => $expectedTags,
                 ),
             ),
-        ), array(
+        ), array('beberlei_metrics.collector.prometheus'), array(
             'prometheus_collector_registry_mock' => $prometheusCollectorRegistryMock,
         ));
 
@@ -415,7 +432,7 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
         ));
     }
 
-    private function createContainer($configs, $additionalServices = array())
+    private function createContainer($configs, $publicServices = array(), $additionalServices = array())
     {
         $container = new ContainerBuilder();
 
@@ -426,6 +443,10 @@ class BeberleiMetricsExtensionTest extends \PHPUnit_Framework_TestCase
 
         foreach ($additionalServices as $serviceId => $additionalService) {
             $container->set($serviceId, $additionalService);
+        }
+
+        foreach($publicServices as $serviceId) {
+            $container->getDefinition($serviceId)->setPublic(true);
         }
 
         $container->compile();

--- a/src/Beberlei/Metrics/Tests/Collector/InMemoryTest.php
+++ b/src/Beberlei/Metrics/Tests/Collector/InMemoryTest.php
@@ -14,8 +14,9 @@
 namespace Beberlei\Metrics\Tests\Collector;
 
 use Beberlei\Metrics\Collector\InMemory;
+use PHPUnit\Framework\TestCase;
 
-class InMemoryTest extends \PHPUnit_Framework_TestCase
+class InMemoryTest extends TestCase
 {
     const VARIABLE_A = 'variable_a';
     const VARIABLE_B = 'variable_b';

--- a/src/Beberlei/Metrics/Tests/Collector/InfluxDBTest.php
+++ b/src/Beberlei/Metrics/Tests/Collector/InfluxDBTest.php
@@ -13,10 +13,11 @@
 
 namespace Beberlei\Metrics\Tests\Collector;
 
+use PHPUnit\Framework\TestCase;
 use PHPUnit_Framework_MockObject_MockObject;
 use Beberlei\Metrics\Collector\InfluxDB;
 
-class InfluxDBTest extends \PHPUnit_Framework_TestCase
+class InfluxDBTest extends TestCase
 {
     /**
      * @var PHPUnit_Framework_MockObject_MockObject

--- a/src/Beberlei/Metrics/Tests/Collector/PrometheusTest.php
+++ b/src/Beberlei/Metrics/Tests/Collector/PrometheusTest.php
@@ -14,9 +14,10 @@
 namespace Beberlei\Metrics\Tests\Collector;
 
 use Beberlei\Metrics\Collector\Prometheus;
+use PHPUnit\Framework\TestCase;
 use Prometheus\Exception\MetricNotFoundException;
 
-class PrometheusTest extends \PHPUnit_Framework_TestCase
+class PrometheusTest extends TestCase
 {
     const TEST_NAMESPACE = 'some_metric_namespace';
     const TEST_VARIABLE_NAME = 'some_variable_name';

--- a/src/Beberlei/Metrics/Tests/FactoryTest.php
+++ b/src/Beberlei/Metrics/Tests/FactoryTest.php
@@ -3,9 +3,10 @@
 namespace Beberlei\Metrics\Tests;
 
 use Beberlei\Metrics\Factory;
+use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 
-class FactoryTest extends \PHPUnit_Framework_TestCase
+class FactoryTest extends TestCase
 {
     public function getCreateValidMetricTests()
     {


### PR DESCRIPTION
Fixes #58.

Currently the (Symfony) class `DefinitionDecorator` is used, which has been renamed to `ChildDefinition`.

Problem at hand: this new class was only introduced in Symfony 3.3.

This is the most clean, but also a bit of an aggressive solution to this problem: require Symfony 3.3 (or 4.0).

- Use `ChildDefinition` over `DefinitionDecorator`
- Symfony 4 makes services private by default, so had to make some of them public in unit-tests.
- Was forced to use `PHPUnit\Framework\TestCase` over `\PHPUnit_Framework_TestCase`, since otherwise I was unable to install the later Symfony versions. This makes it compatible with PHPUnit 6, which is nice.
- Dropped php 5.4 and 5.5 support since Symfony 3 requires php >= 5.5 and PHPUnit does not include the namespaced `TestCase` class. Also they did not receive security updates >6 months by now.
- Dropped hhvm from the travis build since phpunit does not support hhvm: https://github.com/sebastianbergmann/phpunit/issues/2581

An alternative, less aggressive PR can be found at #60.