### PR TITLE
Use socket_create() and socket_sendto() for communicating with StatsD

### DIFF
--- a/src/Beberlei/Metrics/Collector/StatsD.php
+++ b/src/Beberlei/Metrics/Collector/StatsD.php
@@ -92,7 +92,7 @@ class StatsD implements Collector, GaugeableCollector
             return;
         }
 
-        $fp = fsockopen('udp://'.$this->host, $this->port, $errno, $errstr, 1.0);
+        $fp = socket_create(AF_INET, SOCK_DGRAM, SOL_UDP);
 
         if (!$fp) {
             return;
@@ -100,11 +100,11 @@ class StatsD implements Collector, GaugeableCollector
 
         $level = error_reporting(0);
         foreach ($this->data as $line) {
-            fwrite($fp, $this->prefix.$line);
+            socket_sendto($fp, $this->prefix.$line, strlen($this->prefix.$line), 0, $this->host, $this->port);
         }
         error_reporting($level);
 
-        fclose($fp);
+        socket_close($fp);
 
         $this->data = array();
     }


### PR DESCRIPTION
I tested the current implementation of StatsD collector by running netcat and I was not receiving any data. Not sure what is the cause of the problem, but this implementation works as expected.

If anybody wants to try it our, you can run netcat with `nc -ul -p 8125` and you should get something out when you flush metrics.