### PR TITLE
Add flush() to GaugeableCollector interface

### DIFF
--- a/src/Beberlei/Metrics/Collector/GaugeableCollector.php
+++ b/src/Beberlei/Metrics/Collector/GaugeableCollector.php
@@ -22,4 +22,9 @@ interface GaugeableCollector
      * @param int    $value
      */
     public function gauge($variable, $value);
+
+    /**
+     * Sends the metrics to the adapter backend.
+     */
+    public function flush();
 }


### PR DESCRIPTION
The flush method is required regardless of which collector type you're using. By adding this method to the GaugeableCollector interface, the collector type can be type-hinted on by the interface, rather than the implementation.

E.g. I can write

```php
public function deliverMetrics(GaugeableCollector $collector) {
	$collector->gauge('metric', 1);
	$collector->flush();
}
```

instead of 

```php
public function deliverMetrics(StatsD $collector) {
	$collector->gauge('metric', 1);
	$collector->flush();
}
```