### PR TITLE
Update the timing example to use milliseconds, int

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,8 @@ $collector->decrement('foo.bar');
 
 $start = microtime(true);
 $diff  = microtime(true) - $start;
-$collector->timing('foo.bar', $diff);
+$diff_milliseconds = (int) (1000 * $diff);
+$collector->timing('foo.bar', $diff_milliseconds);
 
 $value = 1234;
 $collector->measure('foo.bar', $value);


### PR DESCRIPTION
The timing example provides the time parameter as a float in microseconds, while the interface expects an int in milliseconds. (#70)